### PR TITLE
chore: add test coverage and coverage report to the README

### DIFF
--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -1,0 +1,56 @@
+name: Coverage Report
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  workflow:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+          persist-credentials: false 
+          fetch-depth: 0 
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.22'
+
+    - uses: extractions/setup-just@v1
+
+    - name: Install dependencies
+      run: go mod download
+
+    - name: Test
+      run: |
+        just test-ci
+        go tool cover -func=coverage.out -o=coverage.out
+
+    - name: Go Coverage Badge
+      uses: tj-actions/coverage-badge-go@v2
+      with:
+        filename: coverage.out
+
+    - name: Verify Changed files
+      uses: tj-actions/verify-changed-files@v16
+      id: verify-changed-files
+      with:
+        files: README.md
+
+    - name: Commit changes
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add README.md
+        git commit -m "chore: Updated coverage badge."
+
+    - name: Push changes
+      if: steps.verify-changed-files.outputs.files_changed == 'true'
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ github.token }}
+        branch: ${{ github.head_ref }}

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -1,12 +1,14 @@
 name: Coverage Report
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  workflow_run:
+    workflows: ["Test lint and build"]
+    branches: [main]
+    types:
+      - completed
 
 jobs:
+
   workflow:
     runs-on: ubuntu-latest
     steps:
@@ -21,9 +23,6 @@ jobs:
         go-version: '1.22'
 
     - uses: extractions/setup-just@v1
-
-    - name: Install dependencies
-      run: go mod download
 
     - name: Test
       run: |

--- a/.github/workflows/test_lint_and_build.yml
+++ b/.github/workflows/test_lint_and_build.yml
@@ -1,7 +1,4 @@
-# This workflow will build a golang project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
-
-name: Go
+name: Test lint and build
 
 on:
   push:
@@ -10,7 +7,6 @@ on:
     branches: [ "main" ]
 
 jobs:
-
   workflow:
     runs-on: ubuntu-latest
     steps:
@@ -24,14 +20,14 @@ jobs:
 
     - uses: extractions/setup-just@v1
 
-    - name: Test
-      run: just test
-
     - name: Lint
       uses: golangci/golangci-lint-action@v3
       with:
         version: v1.57.2
         args: --out-format=colored-line-number -v ./...
+
+    - name: Test
+      run: just test-ci
 
     - name: Build
       run: go build -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+coverage.out
+
 playground/

--- a/justfile
+++ b/justfile
@@ -14,6 +14,10 @@ test:
 test-all:
 	go test -tags=integration ./...
 
+# run test generating coverage
+test-ci:
+	go test -v ./... -covermode=count -coverprofile=coverage.out 
+
 # lint the code
 lint:
 	golangci-lint run -v ./...


### PR DESCRIPTION
Closes #9 

- Creates `test-ci` command to just, that generates the code coverage
- Creates a new workflow to add the code coverage percentual badge to the README once the PR is merged to the main


Screnshoots

- How the badge will be

![Screenshot 2024-05-03 at 23 21 48](https://github.com/dionysia-dev/dionysia/assets/30352740/c79b1a8a-66ad-4770-a0fc-68d16f5fe6d7)
